### PR TITLE
Filter out "networkStatusForFlags" from kernel messages

### DIFF
--- a/OS/01/utils/kernel.py
+++ b/OS/01/utils/kernel.py
@@ -33,7 +33,7 @@ def custom_filter(message):
     elif 'USB' in message:
         return message
     # Check for network related keywords
-    elif any(keyword in message for keyword in ['network', 'IP', 'internet', 'LAN', 'WAN', 'router', 'switch']):
+    elif any(keyword in message for keyword in ['network', 'IP', 'internet', 'LAN', 'WAN', 'router', 'switch']) and "networkStatusForFlags" not in message:
         return message
     else:
         return None


### PR DESCRIPTION
This fixes an issue with the app running on OSX and glitching whenever networkStatusForFlags where thrown by the kernel